### PR TITLE
Add secureBox crypto utilities

### DIFF
--- a/src/crypto/secureBox.ts
+++ b/src/crypto/secureBox.ts
@@ -1,0 +1,17 @@
+import sodium from 'libsodium-wrappers'
+
+await sodium.ready
+
+export function seal(plain: Uint8Array, key: Uint8Array): { nonce: Uint8Array; boxed: Uint8Array } {
+  const nonce = sodium.randombytes_buf(sodium.crypto_secretbox_NONCEBYTES)
+  const boxed = sodium.crypto_secretbox_easy(plain, nonce, key)
+  return { nonce, boxed }
+}
+
+export function open(boxed: Uint8Array, nonce: Uint8Array, key: Uint8Array): Uint8Array | null {
+  try {
+    return sodium.crypto_secretbox_open_easy(boxed, nonce, key)
+  } catch {
+    return null
+  }
+}

--- a/tests/crypto.spec.ts
+++ b/tests/crypto.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { seal, open } from '../src/crypto/secureBox'
+import sodium from 'libsodium-wrappers'
+
+describe('secureBox', () => {
+  it('seals and opens a message', async () => {
+    await sodium.ready
+    const key = sodium.randombytes_buf(sodium.crypto_secretbox_KEYBYTES)
+    const msg = sodium.from_string('hello world')
+    const { nonce, boxed } = seal(msg, key)
+    const opened = open(boxed, nonce, key)
+    expect(opened && sodium.to_string(opened)).toBe('hello world')
+  })
+})


### PR DESCRIPTION
## Summary
- create `src/crypto` folder with `secureBox.ts`
- implement seal/open wrappers around libsodium
- add unit tests for seal/open

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68427bc4834083249345cc814b9b1114