### PR TITLE
Add ChatMessage encoding utilities

### DIFF
--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -1,0 +1,18 @@
+export interface ChatMessage {
+  ts: number
+  author: string
+  text: string
+}
+
+export const encode = (m: ChatMessage): Uint8Array => {
+  const msg: ChatMessage = {
+    ts: m.ts ?? Date.now(),
+    author: m.author,
+    text: m.text,
+  }
+  return new TextEncoder().encode(JSON.stringify(msg))
+}
+
+export const decode = (u: Uint8Array): ChatMessage => {
+  return JSON.parse(new TextDecoder().decode(u)) as ChatMessage
+}

--- a/tests/message.spec.ts
+++ b/tests/message.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { encode, decode, ChatMessage } from '../src/types/message'
+
+describe('message encoding', () => {
+  it('round trips message', () => {
+    const msg: ChatMessage = { ts: Date.now(), author: 'alice', text: 'hi' }
+    const bytes = encode(msg)
+    const decoded = decode(bytes)
+    expect(decoded).toEqual(msg)
+  })
+
+  it('fills missing timestamp on encode', () => {
+    const partial = { author: 'bob', text: 'hello' } as unknown as ChatMessage
+    const bytes = encode(partial)
+    const decoded = decode(bytes)
+    expect(typeof decoded.ts).toBe('number')
+    expect(decoded.author).toBe('bob')
+    expect(decoded.text).toBe('hello')
+  })
+})


### PR DESCRIPTION
## Summary
- define `ChatMessage` interface and encoder/decoder
- implement timestamp autofill logic
- test message encode/decode roundtrip and auto timestamp

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68427bc52ffc8324abb8610f52cb69ac