### PR TITLE
task-5: implement ChatService

### DIFF
--- a/src/chat/chatService.ts
+++ b/src/chat/chatService.ts
@@ -1,0 +1,39 @@
+import { seal, open } from '../crypto/secureBox'
+import { createPeer } from '../p2p/node'
+import { encode, decode, ChatMessage } from '../types/message'
+
+const NONCE_LEN = 24
+const TOPIC = 'chat'
+
+export class ChatService {
+  private key: Uint8Array
+  private peerPromise: Promise<ReturnType<typeof createPeer>> | null = null
+
+  constructor(roomKey: Uint8Array) {
+    this.key = roomKey
+  }
+
+  async start(onMsg: (m: ChatMessage) => void): Promise<void> {
+    const peer = await createPeer()
+    this.peerPromise = Promise.resolve(peer)
+    peer.pubsub.subscribe(TOPIC, (data: Uint8Array) => {
+      const nonce = data.slice(0, NONCE_LEN)
+      const boxed = data.slice(NONCE_LEN)
+      const plain = open(boxed, nonce, this.key)
+      if (!plain) return
+      const msg = decode(plain)
+      onMsg(msg)
+    })
+  }
+
+  async send(m: ChatMessage): Promise<void> {
+    if (!this.peerPromise) throw new Error('not started')
+    const peer = await this.peerPromise
+    const plain = encode(m)
+    const { nonce, boxed } = seal(plain, this.key)
+    const payload = new Uint8Array(nonce.length + boxed.length)
+    payload.set(nonce, 0)
+    payload.set(boxed, nonce.length)
+    peer.pubsub.publish(TOPIC, payload)
+  }
+}

--- a/src/crypto/secureBox.ts
+++ b/src/crypto/secureBox.ts
@@ -1,0 +1,17 @@
+import sodium from 'libsodium-wrappers'
+
+await sodium.ready
+
+export function seal(plain: Uint8Array, key: Uint8Array) {
+  const nonce = sodium.randombytes_buf(sodium.crypto_secretbox_NONCEBYTES)
+  const boxed = sodium.crypto_secretbox_easy(plain, nonce, key)
+  return { nonce, boxed }
+}
+
+export function open(boxed: Uint8Array, nonce: Uint8Array, key: Uint8Array): Uint8Array | null {
+  try {
+    return sodium.crypto_secretbox_open_easy(boxed, nonce, key)
+  } catch {
+    return null
+  }
+}

--- a/src/p2p/node.ts
+++ b/src/p2p/node.ts
@@ -1,0 +1,28 @@
+interface PubSub {
+  subscribe(topic: string, handler: (data: Uint8Array) => void): void
+  publish(topic: string, data: Uint8Array): void
+}
+
+interface Peer {
+  pubsub: PubSub
+}
+
+const topics: Record<string, Set<(data: Uint8Array) => void>> = {}
+
+export async function createPeer(): Promise<Peer> {
+  const pubsub: PubSub = {
+    subscribe(topic, handler) {
+      if (!topics[topic]) topics[topic] = new Set()
+      topics[topic].add(handler)
+    },
+    publish(topic, data) {
+      const handlers = topics[topic]
+      if (!handlers) return
+      for (const h of handlers) {
+        // async delivery
+        setTimeout(() => h(data), 0)
+      }
+    }
+  }
+  return { pubsub }
+}

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -1,0 +1,26 @@
+export interface ChatMessage {
+  ts: number
+  author: string
+  text: string
+}
+
+const enc = new TextEncoder()
+const dec = new TextDecoder()
+
+export function encode(m: Partial<ChatMessage>): Uint8Array {
+  const msg: ChatMessage = {
+    ts: m.ts ?? Date.now(),
+    author: m.author ?? '',
+    text: m.text ?? ''
+  }
+  return enc.encode(JSON.stringify(msg))
+}
+
+export function decode(u: Uint8Array): ChatMessage {
+  const obj = JSON.parse(dec.decode(u))
+  return {
+    ts: obj.ts ?? Date.now(),
+    author: obj.author,
+    text: obj.text
+  }
+}

--- a/tests/chatService.spec.ts
+++ b/tests/chatService.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import sodium from 'libsodium-wrappers'
+import { ChatService } from '../src/chat/chatService'
+import { ChatMessage } from '../src/types/message'
+
+beforeAll(async () => {
+  await sodium.ready
+})
+
+describe('ChatService', () => {
+  it('two instances with same key exchange messages successfully', async () => {
+    const key = sodium.randombytes_buf(32)
+    const a = new ChatService(key)
+    const b = new ChatService(key)
+
+    const received: ChatMessage[] = []
+
+    await a.start(() => {})
+    await b.start(msg => received.push(msg))
+
+    const msg: ChatMessage = { ts: Date.now(), author: 'alice', text: 'hi' }
+    await a.send(msg)
+    await new Promise(r => setTimeout(r, 10))
+
+    expect(received[0]).toEqual(msg)
+  })
+
+  it('wrong key fails to decrypt', async () => {
+    const keyA = sodium.randombytes_buf(32)
+    const keyB = sodium.randombytes_buf(32)
+    const a = new ChatService(keyA)
+    const b = new ChatService(keyB)
+
+    const received: ChatMessage[] = []
+
+    await a.start(() => {})
+    await b.start(msg => received.push(msg))
+
+    const msg: ChatMessage = { ts: Date.now(), author: 'alice', text: 'secret' }
+    await a.send(msg)
+    await new Promise(r => setTimeout(r, 10))
+
+    expect(received.length).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- add secure encryption helpers
- define ChatMessage codec
- create a simple PubSub peer factory
- implement ChatService using secureBox and createPeer
- test ChatService message exchange and key mismatch

## Testing
- `npx vitest run tests/chatService.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68427bc75c2c83249b1c3ef987583ab4