### PR TITLE
task-4 peer factory

### DIFF
--- a/src/p2p/node.ts
+++ b/src/p2p/node.ts
@@ -1,0 +1,24 @@
+import { createLibp2p } from 'libp2p'
+import { webRTC } from '@libp2p/webrtc'
+import { circuitRelayTransport } from '@libp2p/circuit-relay-v2'
+import { noise } from '@chainsafe/libp2p-noise'
+import { gossipsub } from '@chainsafe/libp2p-gossipsub'
+import { identify } from '@libp2p/identify'
+import { FaultTolerance } from '@libp2p/interface'
+
+export async function createPeer() {
+  return createLibp2p({
+    addresses: {
+      listen: ['/dns4/relay.signal.libp2p.io/tcp/443/wss/p2p-webrtc-star/']
+    },
+    transports: [circuitRelayTransport(), webRTC()],
+    connectionEncryption: [noise()],
+    transportManager: {
+      faultTolerance: FaultTolerance.NO_FATAL
+    },
+    services: {
+      identify: identify(),
+      pubsub: gossipsub()
+    }
+  })
+}

--- a/tests/peer.spec.ts
+++ b/tests/peer.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import type { Libp2p } from 'libp2p'
+import { createPeer } from '../src/p2p/node'
+
+if (!(Promise as any).withResolvers) {
+  (Promise as any).withResolvers = () => {
+    let resolve: (value?: unknown) => void
+    let reject: (reason?: any) => void
+    const promise = new Promise((res, rej) => { resolve = res; reject = rej })
+    return { promise, resolve: resolve!, reject: reject! }
+  }
+}
+
+let a: Libp2p
+let b: Libp2p
+
+beforeAll(async () => {
+  a = await createPeer()
+  b = await createPeer()
+  await a.dial(b.getMultiaddrs()[0])
+})
+
+afterAll(async () => {
+  await a.stop()
+  await b.stop()
+})
+
+describe('createPeer', () => {
+  it('peers can ping each other', async () => {
+    const res = await a.ping(b.getMultiaddrs()[0])
+    expect(res).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary
- add libp2p peer factory with WebRTC, Noise and GossipSub
- start peers from tests and attempt to ping each other

## Testing
- `npx vitest run tests/peer.spec.ts` *(fails: Cannot read properties of undefined (reading 'getPeerId'))*

------
https://chatgpt.com/codex/tasks/task_e_68427bc5953883248380db96d8064945